### PR TITLE
spectral sequence needs a sync at the end of computation

### DIFF
--- a/include/phat/algorithms/spectral_sequence_reduction.h
+++ b/include/phat/algorithms/spectral_sequence_reduction.h
@@ -75,6 +75,7 @@ namespace phat {
                     }
                 }
             }
+            boundary_matrix.sync();
         }
     };
 }


### PR DESCRIPTION
spectral_sequence_reduction.h should have a boundary_matrix.sync() at the end of computation in order to update the final reduced boundary matrix for extracting persistence pairs.
